### PR TITLE
fixed method that selects column in the picker table view

### DIFF
--- a/lib/LAPickerTableView.m
+++ b/lib/LAPickerTableView.m
@@ -130,27 +130,24 @@
 {
     Log(@"setSelectedColumn: %d", column);
     
-    if(_numberOfColumns && _selectedColumn != column)
-    {
-        // Range is [0, numberOfColumns]
-        if(column > -1 && column < _numberOfColumns)
-        {
-            _contentOffset = [_columnsOffset[column] floatValue];
-            CGPoint selectedColumnContentOffset = CGPointMake(-_firstColumnOffset+_contentOffset+_interColumnSpacing, 0);
-            
-            _selectedColumn = column;
-            _selectedColumnView = _columns[_selectedColumn];
-            
-            if (animated)
-            {
-                [self hideColumns:NO animated:animated];
-                [_scrollView setContentOffset:selectedColumnContentOffset animated:animated];
-            }
-            else {
-                _scrollView.contentOffset = selectedColumnContentOffset;
-            }
-        }
+    // there are no columns, nothing to be done
+    if (_numberOfColumns == 0) {
+        return;
     }
+    
+    // Range is [0, numberOfColumns[
+    if (column < 0 || column >= _numberOfColumns) {
+        return;
+    }
+    
+    _contentOffset = [_columnsOffset[column] floatValue];
+    CGPoint selectedColumnContentOffset = CGPointMake(-_firstColumnOffset+_contentOffset+_interColumnSpacing, 0);
+    
+    _selectedColumn = column;
+    _selectedColumnView = _columns[_selectedColumn];
+    
+    [_scrollView setContentOffset:selectedColumnContentOffset animated:animated];
+    [self hideColumns:NO animated:animated];
 }
 
 - (void)setSelectedColumnHighlighted:(BOOL)highlighted animated:(BOOL)animated;


### PR DESCRIPTION
I guess that for performance reasons we were checking:

`if(_numberOfColumns && _selectedColumn != column)`

but if the initially selected column was the one at index 0 this would cause the rest of the code not being executed, which then caused the cells not to show up in the screen.

I opted for having a worse performance instead of adding a variable to check if the picker was visible or not.

This happens because of the following code inside the **reloadData** method:
`_selectedColumn = 0;
 _selectedColumnView = _columns[_selectedColumn];`